### PR TITLE
cuda-minimal-build v13.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-2
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-2
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.0.2" %}
+{% set version = "13.1.0" %}
 
 package:
   name: cuda-minimal-build
@@ -17,9 +17,9 @@ requirements:
     - __linux  # [linux]
     - __win    # [win]
     - cuda-compiler {{ version }}
-    - cuda-cudart-dev 13.0.96
-    - cuda-cccl 13.0.85
-    - cuda-profiler-api 13.0.85
+    - cuda-cudart-dev 13.1.80
+    - cuda-cccl 13.1.78
+    - cuda-profiler-api 13.1.80
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.1.0" %}
+{% set version = "13.1.1" %}
 
 package:
   name: cuda-minimal-build
@@ -18,8 +18,8 @@ requirements:
     - __win    # [win]
     - cuda-compiler {{ version }}
     - cuda-cudart-dev 13.1.80
-    - cuda-cccl 13.1.78
-    - cuda-profiler-api 13.1.80
+    - cuda-cccl 13.1.115
+    - cuda-profiler-api 13.1.115
 
 test:
   commands:


### PR DESCRIPTION
cuda-minimal-build 13.1.1

**Destination channel:** defaults

### Links

- [PKG-12036](https://anaconda.atlassian.net/browse/PKG-12036) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-compiler-feedstock/pull/7

### Explanation of changes:

- CUDA 13.1 release

### Notes:

- Please refer to the latest PBP run here: https://package-build.anaconda.com/v1/graph/70a9abf2-05c8-4ef2-aa6a-2db68bf49f8b


[PKG-12036]: https://anaconda.atlassian.net/browse/PKG-12036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ