### PR TITLE
cuda-minimal-build v12.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,14 @@ source:
 
 build:
   number: 0
-  noarch: generic
+  # This is 'technically' not a noarch package: only supported on linux-64, linux-aarch64 and windows-64
+  # Therefore, 'noarch: generic' is replaced with 'skip: true' to avoid building on unsupported platforms.
+  skip: true  # [osx]
 
 requirements:
   run:
-    - __linux  # [linux]
-    - __win    # [win]
+    # Remove '__linux' and '__win' as they might not be handled properly on PBP
+    # Also, see above note about 'skip: true'
     - cuda-compiler {{ version }}
     - cuda-cudart-dev 12.8.90
     - cuda-cccl 12.8.90
@@ -30,11 +32,15 @@ about:
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Meta-package containing the minimal necessary to build basic CUDA apps.
   description: |
     Meta-package containing the minimal necessary to build basic CUDA apps.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
+  skip-lints:
+    - license_file_overspecified
   recipe-maintainers:
     - conda-forge/cuda


### PR DESCRIPTION
cuda-minimal-build 12.8.1

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-11172](https://anaconda.atlassian.net/browse/PKG-11172) 

### Explanation of changes:

- Missing package for CUDA 12.8 release


[PKG-11172]: https://anaconda.atlassian.net/browse/PKG-11172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ